### PR TITLE
[11] - Uses testing cache on integration tests

### DIFF
--- a/app/Application/Services/OpenWalletService.php
+++ b/app/Application/Services/OpenWalletService.php
@@ -24,6 +24,11 @@ class OpenWalletService
             return null;
         }
 
-        return $this->walletDataSource->saveWalletInCache();
+        $walletId = $this->walletDataSource->saveWalletInCache();
+        if ($walletId === null) {
+            return 'Cache is full';
+        }
+
+        return $walletId;
     }
 }

--- a/app/Application/Services/OpenWalletService.php
+++ b/app/Application/Services/OpenWalletService.php
@@ -20,7 +20,7 @@ class OpenWalletService
     public function createWallet(string $userId): ?string
     {
         $user = $this->userDataSource->findById($userId);
-        if (is_null($user)) {
+        if ($user === null) {
             return null;
         }
 

--- a/app/Infrastructure/Controllers/PostOpenWalletController.php
+++ b/app/Infrastructure/Controllers/PostOpenWalletController.php
@@ -24,15 +24,15 @@ class PostOpenWalletController extends BaseController
             ], Response::HTTP_NOT_FOUND);
         }
 
-        if ($walletId != "Cache is full") {
+        if (str_contains($walletId, 'Cache is full')) {
             return response()->json([
-                'description' => 'successful operation',
-                'wallet_id' => str($walletId)
-            ], Response::HTTP_OK);
+                'description' => 'cache is full',
+            ], Response::HTTP_NOT_FOUND);
         }
 
         return response()->json([
-            'description' => 'cache is full',
-        ], Response::HTTP_NOT_FOUND);
+            'description' => 'successful operation',
+            'wallet_id' => str($walletId)
+        ], Response::HTTP_OK);
     }
 }

--- a/app/Infrastructure/Controllers/PostOpenWalletController.php
+++ b/app/Infrastructure/Controllers/PostOpenWalletController.php
@@ -24,7 +24,7 @@ class PostOpenWalletController extends BaseController
             ], Response::HTTP_NOT_FOUND);
         }
 
-        if ($walletId) {
+        if ($walletId != "Cache is full") {
             return response()->json([
                 'description' => 'successful operation',
                 'wallet_id' => str($walletId)

--- a/tests/app/Application/Services/OpenWalletServiceTest.php
+++ b/tests/app/Application/Services/OpenWalletServiceTest.php
@@ -55,7 +55,7 @@ class OpenWalletServiceTest extends TestCase
     public function returnsNullWhenUserExistsAndCacheIsFull()
     {
         $this->userDataSource->shouldReceive('findById')->with('2')->andReturn(new User('2'));
-        $this->walletDataSource->shouldReceive('saveWalletInCache')->withNoArgs()->once()->andReturn(null);
+        $this->walletDataSource->shouldReceive('saveWalletInCache')->withNoArgs()->once()->andReturn('Cache is full');
 
         $this->openWalletService->createWallet('2');
     }

--- a/tests/app/Infrastructure/Controller/PostOpenWalletControllerTest.php
+++ b/tests/app/Infrastructure/Controller/PostOpenWalletControllerTest.php
@@ -7,10 +7,12 @@ use App\Domain\User;
 use Mockery;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Cache;
 
 class PostOpenWalletControllerTest extends TestCase
 {
     private UserDataSource $userDataSource;
+
 
     protected function setUp(): void
     {
@@ -46,10 +48,31 @@ class PostOpenWalletControllerTest extends TestCase
             ->expects("findById")
             ->with("0")
             ->andReturn(new User("0"));
+        Cache::shouldReceive('has')->andReturn(false);
+        Cache::shouldReceive('put')
+            ->once()
+            ->with('wallet_0', Mockery::type('array'));
 
         $response = $this->post('api/wallet/open', ["user_id" => "0"]);
 
         $response->assertStatus(JsonResponse::HTTP_OK);
         $response->assertExactJson(['description' => 'successful operation','wallet_id' => 'wallet_0']);
+    }
+
+    /**
+     * @test
+     */
+    public function ifGoodUserIdAndCacheIsFullThrowsError()
+    {
+        $this->userDataSource
+            ->expects("findById")
+            ->with("0")
+            ->andReturn(new User("0"));
+        Cache::shouldReceive('has')->andReturn(true);
+
+        $response = $this->post('api/wallet/open', ["user_id" => "0"]);
+
+        $response->assertStatus(JsonResponse::HTTP_NOT_FOUND);
+        $response->assertExactJson(['description' => 'cache is full']);
     }
 }


### PR DESCRIPTION
**Issue**
- Resolves #11 

**Solution**
- We have used the Laravel test cache to avoid having to mock the walletDataSource in the integration tests
- I have also fixed a bug that did not allow to enter in the event that the cache was full in the controller since the service returned null twice (when the user was not found and when the cache was full).
