### PR TITLE
[15] - findById method on FileWalletDataSource tested

### DIFF
--- a/tests/app/Application/DataSources/WalletDataSourceTest.php
+++ b/tests/app/Application/DataSources/WalletDataSourceTest.php
@@ -4,6 +4,7 @@ namespace Tests\app\Application\DataSources;
 
 use App\Domain\Coin;
 use App\Domain\DataSources\CoinDataSource;
+use App\Domain\Wallet;
 use App\Infrastructure\Persistence\FileWalletDataSource;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -20,6 +21,30 @@ class WalletDataSourceTest extends TestCase
         $this->app->bind(CoinDataSource::class, function () {
             return $this->coinDataSource;
         });
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotFindAWalletIfWalletDoesNotExist()
+    {
+        $walletDataSource = new FileWalletDataSource();
+
+        Cache::shouldReceive('has')->andReturn(false);
+
+        $this->assertEquals(null, $walletDataSource->findById('wallet_0'));
+    }
+
+    /**
+     * @test
+     */
+    public function findAWalletIfWalletExists()
+    {
+        $walletDataSource = new FileWalletDataSource();
+
+        Cache::shouldReceive('has')->andReturn(true);
+
+        $this->assertEquals(new Wallet('wallet_0'), $walletDataSource->findById('wallet_0'));
     }
 
     /**

--- a/tests/app/Application/DataSources/WalletDataSourceTest.php
+++ b/tests/app/Application/DataSources/WalletDataSourceTest.php
@@ -5,6 +5,7 @@ namespace Tests\app\Application\DataSources;
 use App\Domain\Coin;
 use App\Domain\DataSources\CoinDataSource;
 use App\Domain\Wallet;
+use App\Domain\DataSources\WalletDataSource;
 use App\Infrastructure\Persistence\FileWalletDataSource;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -45,6 +46,33 @@ class WalletDataSourceTest extends TestCase
         Cache::shouldReceive('has')->andReturn(true);
 
         $this->assertEquals(new Wallet('wallet_0'), $walletDataSource->findById('wallet_0'));
+    }
+
+    /**
+     * @test
+     */
+    public function savesWalletWhenCacheIsNotFull()
+    {
+        $walletDataSource = new FileWalletDataSource();
+
+        Cache::shouldReceive('has')->andReturn(false);
+        Cache::shouldReceive('put')
+            ->once()
+            ->with('wallet_0', Mockery::type('array'));
+
+        $this->assertEquals('wallet_0', $walletDataSource->saveWalletInCache());
+    }
+
+    /**
+     * @test
+     */
+    public function returnsNullWhenCacheIsFull()
+    {
+        $walletDataSource = new FileWalletDataSource();
+
+        Cache::shouldReceive('has')->andReturn(true);
+
+        $this->assertEquals(null, $walletDataSource->saveWalletInCache());
     }
 
     /**

--- a/tests/app/Application/DataSources/WalletDataSourceTest.php
+++ b/tests/app/Application/DataSources/WalletDataSourceTest.php
@@ -26,7 +26,7 @@ class WalletDataSourceTest extends TestCase
     /**
      * @test
      */
-    public function doesNotFindAWalletIfWalletDoesNotExist()
+    public function returnsNullWhenWalletIdDoesNotExist()
     {
         $walletDataSource = new FileWalletDataSource();
 
@@ -38,7 +38,7 @@ class WalletDataSourceTest extends TestCase
     /**
      * @test
      */
-    public function findAWalletIfWalletExists()
+    public function returnsWalletWhenWalletIdExists()
     {
         $walletDataSource = new FileWalletDataSource();
 


### PR DESCRIPTION
**Issue**
- Resolves #15 

**Solution**
- I have tested the case in which the wallet exists in cache and we return the wallet and the case in which the wallet does not exist and we return nothing.