### PR TITLE
[17] - Integration tests fixed on cryptocurrency wallet controller

### DIFF
--- a/tests/app/Application/DataSources/WalletDataSourceTest.php
+++ b/tests/app/Application/DataSources/WalletDataSourceTest.php
@@ -4,6 +4,7 @@ namespace Tests\app\Application\DataSources;
 
 use App\Domain\Coin;
 use App\Domain\DataSources\CoinDataSource;
+use App\Domain\Wallet;
 use App\Infrastructure\Persistence\FileWalletDataSource;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
@@ -20,6 +21,30 @@ class WalletDataSourceTest extends TestCase
         $this->app->bind(CoinDataSource::class, function () {
             return $this->coinDataSource;
         });
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotFindAWalletIfWalletDoesNotExist()
+    {
+        $walletDataSource = new FileWalletDataSource();
+
+        Cache::shouldReceive('has')->andReturn(false);
+
+        $this->assertEquals(null, $walletDataSource->findById('wallet_0'));
+    }
+
+    /**
+     * @test
+     */
+    public function findAWalletIfWalletExists()
+    {
+        $walletDataSource = new FileWalletDataSource();
+
+        Cache::shouldReceive('has')->andReturn(true);
+
+        $this->assertEquals(new Wallet('wallet_0'), $walletDataSource->findById('wallet_0'));
     }
 
     /**

--- a/tests/app/Infrastructure/Controller/GetsWalletCryptocurrenciesControllerTest.php
+++ b/tests/app/Infrastructure/Controller/GetsWalletCryptocurrenciesControllerTest.php
@@ -14,7 +14,7 @@ class GetsWalletCryptocurrenciesControllerTest extends TestCase
     /**
      * @test
      */
-    public function ifWalletIdNotFoundThrowsError()
+    public function returnsNotFoundMessageWhenWalletDoesNotExist()
     {
         $wallet = new Wallet('0');
 
@@ -29,7 +29,7 @@ class GetsWalletCryptocurrenciesControllerTest extends TestCase
     /**
      * @test
      */
-    public function ifWalletIdExistsGetsWalletCryptocurrencies()
+    public function returnsWalletCryptocurrenciesWhenWalletExists()
     {
         $walletId = '0';
         $walletCoins = [
@@ -41,7 +41,6 @@ class GetsWalletCryptocurrenciesControllerTest extends TestCase
         $wallet = new Wallet($walletId);
 
         Cache::shouldReceive('has')->andReturn(true);
-        ;
         Cache::shouldReceive('get')
             ->with('wallet_' . $walletId)
             ->andReturn(['BuyTimeAccumulatedValue' => 10, 'coins' => $walletCoins]);

--- a/tests/app/Infrastructure/Controller/GetsWalletCryptocurrenciesControllerTest.php
+++ b/tests/app/Infrastructure/Controller/GetsWalletCryptocurrenciesControllerTest.php
@@ -14,7 +14,7 @@ class GetsWalletCryptocurrenciesControllerTest extends TestCase
     /**
      * @test
      */
-    public function returnsNotFoundMessageWhenWalletDoesNotExist()
+    public function walletIdWasNotFoundIfWalletDoesNotExists()
     {
         $wallet = new Wallet('0');
 


### PR DESCRIPTION
**Issue**
- Resolves #17 

**Solution**
- I have used the laravel testing cache to test the controller as we did with OpenWallet, I have deleted a test since it had to do with the request params validation, and I will do that in the next PR fixing the validation :)
