### PR TITLE
[27] - Integration tests do not Mock datasources

### DIFF
--- a/app/Application/Exceptions/WalletNotFoundException.php
+++ b/app/Application/Exceptions/WalletNotFoundException.php
@@ -2,13 +2,13 @@
 
 namespace App\Application\Exceptions;
 
-use Exception;
 use Symfony\Component\HttpFoundation\Response;
+use Exception;
 
-class UserNotFoundException extends Exception
+class WalletNotFoundException extends Exception
 {
     public function __construct()
     {
-        parent::__construct('User not found', Response::HTTP_BAD_REQUEST);
+        parent::__construct('Wallet not found', Response::HTTP_BAD_REQUEST);
     }
 }

--- a/app/Application/Services/WalletBalanceService.php
+++ b/app/Application/Services/WalletBalanceService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Application\Services;
+
+use App\Application\Exceptions\WalletNotFoundException;
+use App\Domain\DataSources\CoinDataSource;
+use App\Domain\DataSources\WalletDataSource;
+
+class WalletBalanceService
+{
+    private WalletDataSource $walletDataSource;
+    private CoinDataSource $coinDataSource;
+
+    public function __construct(WalletDataSource $walletDataSource, CoinDataSource $coinDataSource)
+    {
+        $this->walletDataSource = $walletDataSource;
+        $this->coinDataSource = $coinDataSource;
+    }
+
+    /**
+     * @throws WalletNotFoundException
+     */
+    public function getsBalance($walletId)
+    {
+        if (is_null($this->walletDataSource->findById($walletId))) {
+            throw new WalletNotFoundException();
+        }
+
+        $wallet = $this->walletDataSource->getWalletById($walletId);
+        $accumulatedSum = $wallet['BuyTimeAccumulatedValue'];
+        $totalValue = 0;
+
+        foreach ($wallet['coins'] as $coin) {
+            $coinCurrentValue = $this->coinDataSource->getUsdValue($coin['coinId']);
+            $totalValue += $coinCurrentValue * $coin['amount'];
+        }
+
+        return $totalValue - $accumulatedSum;
+    }
+}

--- a/app/Application/Services/WalletCryptocurrenciesService.php
+++ b/app/Application/Services/WalletCryptocurrenciesService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Application\Services;
+
+use App\Application\Exceptions\WalletNotFoundException;
+use App\Domain\DataSources\WalletDataSource;
+use Illuminate\Support\Facades\Cache;
+
+class WalletCryptocurrenciesService
+{
+    private WalletDataSource $walletDataSource;
+
+    public function __construct(WalletDataSource $walletDataSource)
+    {
+        $this->walletDataSource = $walletDataSource;
+    }
+
+    /**
+     * @throws WalletNotFoundException
+     */
+    public function getWalletCryptocurrencies($walletId): array
+    {
+        $wallet = $this->walletDataSource->findById($walletId);
+        if (is_null($wallet)) {
+            throw new WalletNotFoundException();
+        }
+
+        $walletData = $this->walletDataSource->getWalletById($walletId);
+
+        return $walletData['coins'];
+    }
+}

--- a/app/Domain/DataSources/WalletDataSource.php
+++ b/app/Domain/DataSources/WalletDataSource.php
@@ -14,4 +14,6 @@ interface WalletDataSource
     public function sellCoinFromWallet(string $walletId, Coin $coin, string $amountUsd): void;
 
     public function saveWalletInCache(): ?string;
+
+    public function getWalletById(string $walletId);
 }

--- a/app/Infrastructure/Controllers/GetsWalletBalanceController.php
+++ b/app/Infrastructure/Controllers/GetsWalletBalanceController.php
@@ -2,48 +2,40 @@
 
 namespace App\Infrastructure\Controllers;
 
-use App\Domain\DataSources\CoinDataSource;
-use App\Domain\DataSources\WalletDataSource;
+use App\Application\Exceptions\WalletNotFoundException;
+use App\Application\Services\WalletBalanceService;
+use App\Validators\WalletIdValidator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Validator;
 
 class GetsWalletBalanceController extends BaseController
 {
-    private WalletDataSource $walletDataSource;
-    private CoinDataSource $coinDataSource;
-    public function __construct(WalletDataSource $walletDataSource, CoinDataSource $coinDataSource)
-    {
-        $this->walletDataSource = $walletDataSource;
-        $this->coinDataSource = $coinDataSource;
-    }
-    public function __invoke($wallet_id): JsonResponse
-    {
-        $validator = Validator::make(['wallet_id' => $wallet_id], [
-            'wallet_id' => 'required|int|min:0',
-        ]);
-        if ($validator->fails()) {
-            return response()->json([], Response::HTTP_BAD_REQUEST);
+    /**
+     * @throws WalletNotFoundException
+     */
+    public function __invoke(
+        $walletId,
+        WalletIdValidator $walletIdValidator,
+        WalletBalanceService $walletBalanceService
+    ): JsonResponse {
+        if (!$walletIdValidator->validateWalletId($walletId)) {
+            return response()->json(
+                [
+                    'error' => 'Bad Request',
+                    'message' => $walletIdValidator->getMessage($walletId)
+                ],
+                Response::HTTP_BAD_REQUEST
+            );
         }
 
-        if (is_null($this->walletDataSource->findById($wallet_id))) {
-            return response()->json([
-                'description' => 'A wallet with the specified ID was not found'
-            ], Response::HTTP_NOT_FOUND);
-        }
+        $balance = $walletBalanceService->getsBalance($walletId);
 
-        $walletArray = Cache::get('wallet_' . $wallet_id);
-        $accumulatedSum = $walletArray['BuyTimeAccumulatedValue'];
-        $totalValue = 0;
-
-        foreach ($walletArray['coins'] as $coin) {
-            $coinCurrentValue = $this->coinDataSource->getUsdValue($coin['coinId']);
-            $totalValue += $coinCurrentValue * $coin['amount'];
-        }
-
-        $balance = $totalValue - $accumulatedSum;
-        return response()->json(['balance_usd' => $balance], Response::HTTP_OK);
+        return response()->json(
+            [
+                'balance_usd' => $balance
+            ],
+            Response::HTTP_OK
+        );
     }
 }

--- a/app/Infrastructure/Controllers/GetsWalletCryptocurrenciesController.php
+++ b/app/Infrastructure/Controllers/GetsWalletCryptocurrenciesController.php
@@ -2,35 +2,31 @@
 
 namespace App\Infrastructure\Controllers;
 
-use App\Domain\DataSources\WalletDataSource;
+use App\Application\Services\WalletCryptocurrenciesService;
 use App\Validators\WalletIdValidator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller as BaseController;
-use Illuminate\Support\Facades\Cache;
 
 class GetsWalletCryptocurrenciesController extends BaseController
 {
-    private WalletDataSource $walletDataSource;
-
-    public function __construct(WalletDataSource $walletDataSource)
-    {
-        $this->walletDataSource = $walletDataSource;
-    }
-    public function __invoke($wallet_id, WalletIdValidator $walletIdValidator): JsonResponse
-    {
-        if (!$walletIdValidator->validateWalletId($wallet_id)) {
-            return response()->json(['error' => 'Bad Request',
-                'message' => $walletIdValidator->getMessage($wallet_id)], Response::HTTP_BAD_REQUEST);
-        }
-        if (is_null($this->walletDataSource->findById($wallet_id))) {
-            return response()->json([
-                'description' => 'A wallet with the specified ID was not found'
-            ], Response::HTTP_NOT_FOUND);
+    public function __invoke(
+        $walletId,
+        WalletIdValidator $walletIdValidator,
+        WalletCryptocurrenciesService $walletCryptocurrenciesService
+    ): JsonResponse {
+        if (!$walletIdValidator->validateWalletId($walletId)) {
+            return response()->json(
+                [
+                    'error' => 'Bad Request',
+                    'message' => $walletIdValidator->getMessage($walletId)
+                ],
+                Response::HTTP_BAD_REQUEST
+            );
         }
 
-        $walletArray = Cache::get('wallet_' . $wallet_id);
+        $walletCryptocurrencies = $walletCryptocurrenciesService->getWalletCryptocurrencies($walletId);
 
-        return response()->json([$walletArray['coins']], Response::HTTP_OK);
+        return response()->json($walletCryptocurrencies, Response::HTTP_OK);
     }
 }

--- a/app/Infrastructure/Exceptions/Handler.php
+++ b/app/Infrastructure/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Infrastructure\Exceptions;
 
 use App\Application\Exceptions\UserNotFoundException;
+use App\Application\Exceptions\WalletNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,10 +50,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception): Response
     {
-        if ($exception instanceof UserNotFoundException) {
+        if ($exception instanceof UserNotFoundException || $exception instanceof WalletNotFoundException) {
             return response()->json([
                 'description' => $exception->getMessage()
-            ], Response::HTTP_NOT_FOUND);
+            ], $exception->getCode());
         }
 
         return parent::render($request, $exception);

--- a/app/Infrastructure/Persistence/CacheWalletDataSource.php
+++ b/app/Infrastructure/Persistence/CacheWalletDataSource.php
@@ -9,10 +9,10 @@ use Illuminate\Support\Facades\Cache;
 
 class CacheWalletDataSource implements WalletDataSource
 {
-    public function findById(string $wallet_id): ?Wallet
+    public function findById(string $walletId): ?Wallet
     {
-        if (Cache::has('wallet_' . $wallet_id)) {
-            return new Wallet($wallet_id);
+        if (Cache::has('wallet_' . $walletId)) {
+            return new Wallet($walletId);
         }
         return null;
     }
@@ -66,6 +66,12 @@ class CacheWalletDataSource implements WalletDataSource
                 return 'wallet_' . $i;
             }
         }
+
         return null;
+    }
+
+    public function getWalletById(string $walletId): array
+    {
+        return Cache::get('wallet_' . $walletId);
     }
 }

--- a/tests/app/Application/Services/OpenWalletServiceTest.php
+++ b/tests/app/Application/Services/OpenWalletServiceTest.php
@@ -31,7 +31,7 @@ class OpenWalletServiceTest extends TestCase
     /**
      * @test
      */
-    public function returnsNullWhenUserNotFound()
+    public function userNotFoundIfUserDoesNotExist()
     {
         $this->userDataSource->shouldReceive('findById')->with('123')->andReturnNull();
         $this->walletDataSource->shouldReceive('saveWalletInCache')->never();

--- a/tests/app/Application/Services/WalletBalanceServiceTest.php
+++ b/tests/app/Application/Services/WalletBalanceServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\app\Application\Services;
+
+use App\Application\Exceptions\WalletNotFoundException;
+use App\Application\Services\WalletBalanceService;
+use App\Domain\Coin;
+use App\Domain\DataSources\CoinDataSource;
+use App\Domain\DataSources\WalletDataSource;
+use App\Domain\Wallet;
+use Mockery;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Tests\TestCase;
+
+class WalletBalanceServiceTest extends TestCase
+{
+    private WalletDataSource $walletDataSource;
+    private CoinDataSource $coinDataSource;
+    private WalletBalanceService $walletBalanceService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->walletDataSource = Mockery::mock(WalletDataSource::class);
+        $this->coinDataSource = Mockery::mock(CoinDataSource::class);
+        $this->walletBalanceService = new WalletBalanceService($this->walletDataSource, $this->coinDataSource);
+    }
+
+    /**
+     * @test
+     */
+    public function walletNotFoundIfWalletDoesNotExist()
+    {
+        $this->walletDataSource
+            ->shouldReceive("findById")
+            ->with("notFound")
+            ->once()
+            ->andReturn(null);
+
+        $this->expectException(WalletNotFoundException::class);
+        $this->expectExceptionMessage('Wallet not found');
+        $this->expectExceptionCode(JsonResponse::HTTP_BAD_REQUEST);
+
+        $this->walletBalanceService->getsBalance("notFound");
+    }
+
+    /**
+     * @test
+     */
+    public function getsWalletBalanceIfWalletExists()
+    {
+        $coinId = '90';
+        $coinValue = '50';
+        $coinAmount = 4;
+        $walletId = '0';
+        $walletCoins = [
+            (new Coin('90', 'Bitcoin', 'BTC', $coinAmount, $coinValue))->getJsonData(),
+        ];
+        $walletBuyTimeAccumulatedValue = '50';
+
+        $this->walletDataSource
+            ->shouldReceive("findById")
+            ->with($walletId)
+            ->once()
+            ->andReturn(new Wallet('0'));
+        $this->walletDataSource
+            ->shouldReceive("getWalletById")
+            ->with($walletId)
+            ->once()
+            ->andReturn(
+                [
+                    'BuyTimeAccumulatedValue' => $walletBuyTimeAccumulatedValue,
+                    'coins' => $walletCoins
+                ]
+            );
+        $this->coinDataSource
+            ->shouldReceive("getUsdValue")
+            ->with($coinId)
+            ->andReturn($coinValue);
+
+        $balance = $this->walletBalanceService->getsBalance($walletId);
+
+        $this->assertEquals($balance, ($coinAmount * $coinValue) - $walletBuyTimeAccumulatedValue);
+    }
+}

--- a/tests/app/Application/Services/WalletCryptocurrenciesServiceTest.php
+++ b/tests/app/Application/Services/WalletCryptocurrenciesServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\app\Application\Services;
+
+use App\Application\Exceptions\WalletNotFoundException;
+use App\Application\Services\WalletCryptocurrenciesService;
+use App\Domain\Coin;
+use App\Domain\DataSources\WalletDataSource;
+use App\Domain\Wallet;
+use Illuminate\Support\Facades\Cache;
+use Mockery;
+use Tests\TestCase;
+
+class WalletCryptocurrenciesServiceTest extends TestCase
+{
+    private WalletCryptocurrenciesService $walletCryptocurrenciesService;
+    private WalletDataSource $walletDataSource;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->walletDataSource = Mockery::mock(WalletDataSource::class);
+        $this->walletCryptocurrenciesService = new WalletCryptocurrenciesService($this->walletDataSource);
+    }
+
+    /**
+     * @test
+     */
+    public function walletNotFoundIfWalletDoesNotExist()
+    {
+        $this->walletDataSource
+            ->shouldReceive("findById")
+            ->with("notFound")
+            ->once()
+            ->andReturn(null);
+
+        $this->expectException(WalletNotFoundException::class);
+        $this->expectExceptionMessage('Wallet not found');
+
+        $this->walletCryptocurrenciesService->getWalletCryptocurrencies("notFound");
+    }
+
+    /**
+     * @test
+     */
+    public function getsWalletCryptocurrenciesWhenWalletFound()
+    {
+        $walletId = "0";
+        $coins = [
+            (new Coin('90', 'Bitcoin', 'BTC', 4, 26829.64))->getJsonData(),
+            (new Coin('80', 'Ethereum', 'ETH', 10, 1830))->getJsonData(),
+            (new Coin('518', 'Tether', 'USDT', 2, 1.00))->getJsonData(),
+        ];
+
+        $this->walletDataSource
+            ->shouldReceive("findById")
+            ->with("0")
+            ->andReturn(new Wallet($walletId));
+        $this->walletDataSource
+            ->shouldReceive('getWalletById')
+            ->with($walletId)
+            ->andReturn(['coins' => $coins]);
+        Cache::shouldReceive("get")
+            ->with("wallet_0")
+            ->andReturn(new Wallet('0'));
+
+        $this->assertEquals($coins, $this->walletCryptocurrenciesService->getWalletCryptocurrencies($walletId));
+    }
+}

--- a/tests/app/Infrastructure/Controller/GetsWalletBalanceControllerTest.php
+++ b/tests/app/Infrastructure/Controller/GetsWalletBalanceControllerTest.php
@@ -39,8 +39,8 @@ class GetsWalletBalanceControllerTest extends TestCase
 
         $response = $this->get('api/wallet/' . $walletOne->getWalletId() . '/balance');
 
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $response->assertExactJson(['description' => 'A wallet with the specified ID was not found']);
+        $response->assertStatus(Response::HTTP_BAD_REQUEST);
+        $response->assertExactJson(['description' => 'Wallet not found']);
     }
 
     /**

--- a/tests/app/Infrastructure/Controller/GetsWalletBalanceControllerTest.php
+++ b/tests/app/Infrastructure/Controller/GetsWalletBalanceControllerTest.php
@@ -66,7 +66,7 @@ class GetsWalletBalanceControllerTest extends TestCase
 
         $response = $this->get('api/wallet/' . $wallet->getWalletId() . '/balance');
         $expectedBalance = ($coinCurrentValue * $coinAmount) - $coinBuyTimeAccumulatedValue;
-        
+
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJson(['balance_usd' => $expectedBalance]);
     }

--- a/tests/app/Infrastructure/Controller/GetsWalletCryptocurrenciesControllerTest.php
+++ b/tests/app/Infrastructure/Controller/GetsWalletCryptocurrenciesControllerTest.php
@@ -3,10 +3,10 @@
 namespace Tests\app\Infrastructure\Controller;
 
 use App\Domain\Coin;
-use App\Domain\DataSources\WalletDataSource;
 use App\Domain\Wallet;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Cache;
-use Mockery;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class GetsWalletCryptocurrenciesControllerTest extends TestCase
@@ -22,8 +22,8 @@ class GetsWalletCryptocurrenciesControllerTest extends TestCase
 
         $response = $this->get('api/wallet/' . $wallet->getWalletId());
 
-        $response->assertNotFound();
-        $response->assertExactJson(['description' => 'A wallet with the specified ID was not found']);
+        $response->assertStatus(JsonResponse::HTTP_BAD_REQUEST);
+        $response->assertExactJson(['description' => 'Wallet not found']);
     }
 
     /**
@@ -47,7 +47,7 @@ class GetsWalletCryptocurrenciesControllerTest extends TestCase
 
         $response = $this->get('api/wallet/' . $wallet->getWalletId());
 
-        $response->assertOk();
-        $response->assertJson([$walletCoins]);
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJson($walletCoins);
     }
 }

--- a/tests/app/Infrastructure/Controller/PostBuyCoinControllerTest.php
+++ b/tests/app/Infrastructure/Controller/PostBuyCoinControllerTest.php
@@ -7,6 +7,7 @@ use App\Domain\DataSources\CoinDataSource;
 use App\Domain\DataSources\WalletDataSource;
 use App\Domain\Wallet;
 use Mockery;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class PostBuyCoinControllerTest extends TestCase
@@ -41,7 +42,7 @@ class PostBuyCoinControllerTest extends TestCase
                                                       "wallet_id" => "wallet_id_value",
                                                       "amount_usd" => 1]);
 
-        $response->assertNotFound();
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
         $response->assertExactJson(['description' => 'A coin with the specified ID was not found.']);
     }
 
@@ -60,7 +61,7 @@ class PostBuyCoinControllerTest extends TestCase
                                                     "wallet_id" => null,
                                                     "amount_usd" => null]);
 
-        $response->assertBadRequest();
+        $response->assertStatus(Response::HTTP_BAD_REQUEST);
         $response->assertExactJson(['description' => 'bad request error']);
     }
 
@@ -90,7 +91,7 @@ class PostBuyCoinControllerTest extends TestCase
                                                     "wallet_id" => "wallet_id_value",
                                                     "amount_usd" => 1]);
 
-        $response->assertOk();
+        $response->assertStatus(Response::HTTP_OK);
         $response->assertExactJson(['description' => 'successful operation']);
     }
 }

--- a/tests/app/Infrastructure/Controller/PostOpenWalletControllerTest.php
+++ b/tests/app/Infrastructure/Controller/PostOpenWalletControllerTest.php
@@ -35,7 +35,7 @@ class PostOpenWalletControllerTest extends TestCase
 
         $response = $this->post('api/wallet/open', ["user_id" => "1"]);
 
-        $response->assertStatus(JsonResponse::HTTP_NOT_FOUND);
+        $response->assertStatus(JsonResponse::HTTP_BAD_REQUEST);
         $response->assertExactJson(['description' => 'User not found']);
     }
 

--- a/tests/app/Infrastructure/Controller/PostSellCoinControllerTest.php
+++ b/tests/app/Infrastructure/Controller/PostSellCoinControllerTest.php
@@ -7,6 +7,7 @@ use App\Domain\DataSources\CoinDataSource;
 use App\Domain\DataSources\WalletDataSource;
 use App\Domain\Wallet;
 use Mockery;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class PostSellCoinControllerTest extends TestCase
@@ -36,7 +37,7 @@ class PostSellCoinControllerTest extends TestCase
                                                     "wallet_id" => null,
                                                     "amount_usd" => null]);
 
-        $response->assertBadRequest();
+        $response->assertStatus(Response::HTTP_BAD_REQUEST);
         $response->assertExactJson(['description' => 'bad request error']);
     }
 
@@ -54,7 +55,7 @@ class PostSellCoinControllerTest extends TestCase
             "wallet_id" => "wallet_id_value",
             "amount_usd" => 1]);
 
-        $response->assertNotFound();
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
         $response->assertExactJson(['description' => 'A coin with the specified ID was not found']);
     }
 
@@ -77,7 +78,7 @@ class PostSellCoinControllerTest extends TestCase
             "amount_usd" => 1]);
 
 
-        $response->assertNotFound();
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
         $response->assertExactJson(['description' => 'A wallet with the specified ID was not found']);
     }
 
@@ -108,7 +109,7 @@ class PostSellCoinControllerTest extends TestCase
             "wallet_id" => "walletId",
             "amount_usd" => 1]);
 
-        $response->assertOk();
+        $response->assertStatus(Response::HTTP_OK);
         $response->assertExactJson(['description' => 'successful operation']);
     }
 }


### PR DESCRIPTION
**Issue**
- Resolves #27 

**Solution**
- Integration tests no longer mock DataSources.
- I have deleted a test since it deals with the validation of the parameters which is already tested in WalletIdValidatorTest, in #28 this validator will be used in the controller.