### PR TITLE
[59] - Empty wallet case tested on WalletCryptocurrencies and WalletBalance

### DIFF
--- a/tests/app/Application/Services/WalletBalanceServiceTest.php
+++ b/tests/app/Application/Services/WalletBalanceServiceTest.php
@@ -48,6 +48,36 @@ class WalletBalanceServiceTest extends TestCase
     /**
      * @test
      */
+    public function getsZeroBalanceWhenWalletExistsAndIsEmpty()
+    {
+        $walletId = '0';
+        $walletCoins = [];
+        $walletBuyTimeAccumulatedValue = '0';
+
+        $this->walletDataSource
+            ->shouldReceive("findById")
+            ->with($walletId)
+            ->once()
+            ->andReturn(new Wallet('0'));
+        $this->walletDataSource
+            ->shouldReceive("getWalletById")
+            ->with($walletId)
+            ->once()
+            ->andReturn(
+                [
+                    'BuyTimeAccumulatedValue' => $walletBuyTimeAccumulatedValue,
+                    'coins' => $walletCoins
+                ]
+            );
+
+        $balance = $this->walletBalanceService->execute($walletId);
+
+        $this->assertEquals(0, $balance);
+    }
+
+    /**
+     * @test
+     */
     public function getsWalletBalanceIfWalletExists()
     {
         $coinId = '90';

--- a/tests/app/Application/Services/WalletCryptocurrenciesServiceTest.php
+++ b/tests/app/Application/Services/WalletCryptocurrenciesServiceTest.php
@@ -44,6 +44,26 @@ class WalletCryptocurrenciesServiceTest extends TestCase
     /**
      * @test
      */
+    public function emptyCryptocurrenciesWhenWalletExistsAndIsEmpty()
+    {
+        $walletId = "0";
+        $coins = [];
+
+        $this->walletDataSource
+            ->shouldReceive("findById")
+            ->with("0")
+            ->andReturn(new Wallet($walletId));
+        $this->walletDataSource
+            ->shouldReceive('getWalletById')
+            ->with($walletId)
+            ->andReturn(['coins' => $coins]);
+
+        $this->assertEquals($coins, $this->walletCryptocurrenciesService->execute($walletId));
+    }
+
+    /**
+     * @test
+     */
     public function getsWalletCryptocurrenciesWhenWalletFound()
     {
         $walletId = "0";


### PR DESCRIPTION
**Issue**
- Resolves #59 

**Solution**
- I have tested the cases in which the wallet is empty in the Balance and the Cryptocurrencies.
